### PR TITLE
Update original logo source

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ Also comes with `svg` version (`deno_hr.svg`).
 
 Comparing to the original Deno logo by [@ry](https://github.com/ry):
 
-<img src="https://deno.land/deno_logo.png" alt="logo" width="300"/>
+<img src="https://deno.land/images/deno_logo.png" alt="logo" width="300"/>


### PR DESCRIPTION
The "original logo" image is currently broken. This PR updates the url to the one used at https://deno.land/manual#logos